### PR TITLE
Bug/fix setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     scripts=[],
     license='LICENSE',
     install_requires=[
-        'waltz >= 0.1.64',
+        'waltz >= 0.1.68',
         'lepl >= 5.1.3',
         'whoosh >= 2.4.1',
         'pypdf',


### PR DESCRIPTION
travis-ci tests probably failing due to test/ still being referenced as a package, even though it has been moved back a directory from openjournal/openjournal/test to openjournal/test.

Updated the waltz dependency version in setup.py 
